### PR TITLE
Removed module duplication

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -41,7 +41,6 @@
     "jwt-decode": "^1.4.0",
     "lodash": "3.10.1",
     "morgan": "^1.6.1",
-    "node-sass": "^3.4.0",
     "normalize.css": "3.0.3",
     "normalizr": "^1.3.1",
     "react": "^0.14.0-rc1",
@@ -60,7 +59,6 @@
   },
   "devDependencies": {
     "autoprefixer-core": "^5.2.1",
-    "babel-core": "^5.8.25",
     "babel-eslint": "^4.1.1",
     "babel-loader": "^5.3.2",
     "babel-plugin-react-transform": "^1.1.1",


### PR DESCRIPTION
1. `babel-core` was in dependencies and devDependencies. Removed the devDependency.
2. `node-sass` was also in both. Since it shouldn't be necessary in production, I kept it as a devDependency and removed it from dependencies.

Great generator, keep up the awesome job!
